### PR TITLE
Add Portuguese and Spanish documentation

### DIFF
--- a/1.executive-summary.es.md
+++ b/1.executive-summary.es.md
@@ -1,0 +1,188 @@
+## 1. Resumen Ejecutivo — "¿Por qué ABIntel?"
+
+### Desafío vs Resultado
+
+| **Desafío**                       | **Resultado de ABIntel (Probado en Producción)** |
+| --------------------------------- | ------------------------------------------------ |
+| Datos en silos desconectados, sin equipo de ML | ✅ Microservicios plug-and-play que ingieren transacciones, facturas, tickets, flujos de sensores o texto libre y entregan predicciones accionables en < 60 s. |
+| Tiempo para generar valor lento   | ✅ Primera campaña o proyecto de costos en ≤ 2 horas; aumento típico de 6–14 % en EBIT dentro de un trimestre fiscal. |
+| Falta de experiencia en GPU       | ✅ El cambio a GPU o el fallback seguro en CPU es automático. |
+| Transferencias entre Datos y Negocio | ✅ Cada respuesta incluye narrativas en inglés, español y portugués para que marketing, planificación y finanzas entiendan el "¿y qué?" al instante. |
+
+---
+
+## 1.1 Arquitectura de la Plataforma en Resumen
+
+* 🧩 Kubernetes con autoscaling hasta **32× T4s** (o **H100s en el Q4 de 2025**)
+* 🔐 Auditoría SOC 2 Tipo 2 en progreso; centros de datos certificados **ISO 27001**
+* 🚀 **Canary releases** sin tiempo de inactividad
+* 🏷️ Versionado semántico mediante `/v1`
+
+---
+
+## 1.2 Servidor de la API
+
+```
+https://api-prod.abintel.app
+```
+
+---
+
+## 1.3 Encolar una Tarea → `POST /ai/{downstream_route}`
+
+### Ejemplo
+
+```http
+POST /api/v1/ai/forecast_revenue
+```
+
+#### Encabezados
+
+```http
+X-Customer-Api-Id: 4d09ffe5-33d7-4a63-b4fd-fc1decf4fa8f
+X-Secret: AfIqb2F9JNET_…HzHUa0w
+```
+
+#### Cuerpo
+
+```json
+{
+  "region": "EU",
+  "horizon": 12,
+  "include_promotions": true
+}
+```
+
+### Tras Bambalinas
+
+1. El proxy verifica tu plan → mapeo de cola (`Business → tasks-medium`)
+2. Comprueba si la ruta downstream está permitida
+3. La tarea se guarda en **Cosmos DB** con `status: "queued"`
+4. Se debita un `UsageRecord`
+5. El trabajo se encola en **Azure Service Bus**
+6. El worker ejecuta el modelo de IA → escribe `status: "completed"` en Cosmos DB
+
+### Respuesta (HTTP 202 - Queued)
+
+```json
+{
+  "task_id": "c7d1b5e76c67485eab1c9a407f7e6a97",
+  "queue": "tasks-medium",
+  "status": "queued"
+}
+```
+
+> 💡 Consejo: Todo lo que envíes por `POST` se almacena exactamente como lo enviaste. Puedes mandar objetos grandes y anidados.
+
+---
+
+## 1.4 Verificar Estado / Descargar Resultados
+
+### 1.4.1 Listar Trabajos Recientes
+
+```http
+GET /api/v1/taskadmin/tasks?status_filter=completed&limit=20
+```
+
+Mismos encabezados de autenticación.
+
+### 1.4.2 Recuperar un Trabajo
+
+```http
+GET /api/v1/taskadmin/tasks/{task_id}?part=response
+```
+
+#### Ejemplo – Éxito
+
+```json
+{
+  "auc": 0.912,
+  "predictions": [ ... ],
+  "interpretation": "Modelo XGBoost – buena separación."
+}
+```
+
+#### Ejemplo – Falla
+
+```json
+{
+  "error": "HTTP 500 Server Error: …",
+  "status_code": 500
+}
+```
+
+---
+
+## 1.5 Dashboards de Cola y Workers
+
+| **Endpoint**                  | **Uso**                                                          | **Ejemplo** |
+| ----------------------------- | ---------------------------------------------------------------- | ----------- |
+| `GET /taskadmin/queue/stats`  | Resumen: cantidades en cola / completadas / fallidas por cola + trabajo más antiguo | `GET /api/v1/taskadmin/queue/stats` |
+| `GET /taskadmin/queue/queued` | Volcado paginado para dashboards personalizados                   | `GET /api/v1/taskadmin/queue/queued?queue=medium` |
+
+> 🧠 Ambos endpoints consultan Cosmos DB – sin carga en los workers.
+
+---
+
+## 1.6 APIs de Uso / Facturación
+
+| Endpoint                       | Descripción                          |
+| ------------------------------ | ------------------------------------ |
+| `GET /taskadmin/usage/month`   | Número de llamadas y costo del mes   |
+| `GET /taskadmin/usage/history` | Historial de uso y costo por mes     |
+
+#### Ejemplo de Respuesta
+
+```json
+{
+  "month": "2025-05",
+  "calls": 842,
+  "cost": 42.10
+}
+```
+
+> 💰 Los costos se derivan de `UsageRecord.cost`. Puedes definir precios por ruta.
+
+---
+
+## 1.7 Ciclo Típico
+
+```
+sequenceDiagram
+    Customer ->> Proxy /ai/... : POST payload
+    Proxy ->> Cosmos DB : Save task (status="queued")
+    Proxy ->> Azure Service Bus : Enqueue task
+    Celery Worker ->> Azure Bus : Poll
+    Worker ->> AI Backend : POST for processing
+    Worker ->> Cosmos DB : Save (status="completed" + response)
+    Customer ->> /taskadmin/tasks/{id}?part=response : Fetch result
+```
+
+---
+
+## 1.8 Guía Rápida de Manejo de Errores
+
+| **Status**  | **Significado**          | **Próximo Paso**                           |
+| ----------- | ------------------------ | ------------------------------------------- |
+| `queued`    | Esperando un worker libre | Revisa `/queue/stats` para ver el backlog   |
+| `completed` | Resultado listo           | Descárgalo                                  |
+| `failed`    | Error o timeout           | Revisa el campo `error`; reintenta si es transitorio |
+
+---
+
+## 1.9 FAQ
+
+* **¿Cuánto tiempo se conservan los resultados?**
+  ⏳ 30 días (por defecto)
+
+* **¿Puedo cancelar un trabajo?**
+  ❌ Aún no – abre un ticket de soporte
+
+* **¿Timeouts?**
+  ⏱️ Timeout fijo de 60 s; divide trabajos grandes
+
+* **¿Seguridad?**
+  🔐 TLS 1.2 para todos los datos en tránsito
+  🔒 Secretos con hash en reposo
+
+---

--- a/1.executive-summary.pt.md
+++ b/1.executive-summary.pt.md
@@ -1,0 +1,188 @@
+## 1. Resumo Executivo — "Por que ABIntel?"
+
+### Desafio vs Resultado
+
+| **Desafio**                        | **Resultado da ABIntel (Comprovado em Produção)** |
+| ---------------------------------- | ------------------------------------------------- |
+| Dados em silos desconectados, sem equipe de ML | ✅ Microsserviços plug-and-play que ingerem transações, faturas, tickets, fluxos de sensores ou texto livre e entregam previsões acionáveis em < 60s. |
+| Tempo para gerar valor é lento     | ✅ Primeira campanha ou projeto de custos no ar em ≤ 2 horas; aumento típico de 6–14% no EBIT dentro de um trimestre fiscal. |
+| Falta de expertise em GPU          | ✅ Alternância para GPU ou fallback seguro em CPU é automática. |
+| Passes entre Dados e Negócios      | ✅ Cada resposta contém narrativas em inglês, espanhol e português para que marketing, planejamento e finanças entendam o "e daí?" instantaneamente. |
+
+---
+
+## 1.1 Arquitetura da Plataforma em Destaque
+
+* 🧩 Kubernetes com autoscaling até **32× T4s** (ou **H100s no 4º tri de 2025**)
+* 🔐 Auditoria SOC 2 Tipo 2 em progresso; datacenters certificados **ISO 27001**
+* 🚀 **Canary releases** sem downtime
+* 🏷️ Versionamento semântico via `/v1`
+
+---
+
+## 1.2 Servidor da API
+
+```
+https://api-prod.abintel.app
+```
+
+---
+
+## 1.3 Enfileirar uma Tarefa → `POST /ai/{downstream_route}`
+
+### Exemplo
+
+```http
+POST /api/v1/ai/forecast_revenue
+```
+
+#### Cabeçalhos
+
+```http
+X-Customer-Api-Id: 4d09ffe5-33d7-4a63-b4fd-fc1decf4fa8f
+X-Secret: AfIqb2F9JNET_…HzHUa0w
+```
+
+#### Corpo
+
+```json
+{
+  "region": "EU",
+  "horizon": 12,
+  "include_promotions": true
+}
+```
+
+### Por trás dos Bastidores
+
+1. Proxy verifica seu plano → mapeamento de fila (`Business → tasks-medium`)
+2. Valida se o caminho downstream é permitido
+3. Tarefa salva no **Cosmos DB** com `status: "queued"`
+4. Um `UsageRecord` debitado
+5. Job é enfileirado no **Azure Service Bus**
+6. Worker executa o modelo de IA → grava `status: "completed"` no Cosmos DB
+
+### Resposta (HTTP 202 - Queued)
+
+```json
+{
+  "task_id": "c7d1b5e76c67485eab1c9a407f7e6a97",
+  "queue": "tasks-medium",
+  "status": "queued"
+}
+```
+
+> 💡 Dica: Tudo que você `POST` é armazenado exatamente como enviado. É possível mandar objetos grandes e aninhados.
+
+---
+
+## 1.4 Verificar Status / Baixar Resultados
+
+### 1.4.1 Listar Jobs Recentes
+
+```http
+GET /api/v1/taskadmin/tasks?status_filter=completed&limit=20
+```
+
+Mesmos cabeçalhos de autenticação.
+
+### 1.4.2 Buscar um Job
+
+```http
+GET /api/v1/taskadmin/tasks/{task_id}?part=response
+```
+
+#### Exemplo – Sucesso
+
+```json
+{
+  "auc": 0.912,
+  "predictions": [ ... ],
+  "interpretation": "Modelo XGBoost – boa separação."
+}
+```
+
+#### Exemplo – Falha
+
+```json
+{
+  "error": "HTTP 500 Server Error: …",
+  "status_code": 500
+}
+```
+
+---
+
+## 1.5 Dashboards de Fila e Workers
+
+| **Endpoint**                  | **Uso**                                                         | **Exemplo** |
+| ----------------------------- | ---------------------------------------------------------------- | ----------- |
+| `GET /taskadmin/queue/stats`  | Resumo – contagem de jobs enfileirados / concluídos / falhos por fila + job mais antigo | `GET /api/v1/taskadmin/queue/stats` |
+| `GET /taskadmin/queue/queued` | Dump paginado para dashboards personalizados                     | `GET /api/v1/taskadmin/queue/queued?queue=medium` |
+
+> 🧠 Ambos os endpoints consultam o Cosmos DB – nenhum impacto nos workers.
+
+---
+
+## 1.6 APIs de Uso / Cobrança
+
+| Endpoint                       | Descrição                             |
+| ------------------------------ | ------------------------------------- |
+| `GET /taskadmin/usage/month`   | Contagem de chamadas e custo do mês   |
+| `GET /taskadmin/usage/history` | Histórico de uso e custo por mês      |
+
+#### Exemplo de Resposta
+
+```json
+{
+  "month": "2025-05",
+  "calls": 842,
+  "cost": 42.10
+}
+```
+
+> 💰 Custos são derivados de `UsageRecord.cost`. É possível definir preços por rota.
+
+---
+
+## 1.7 Ciclo Típico
+
+```
+sequenceDiagram
+    Customer ->> Proxy /ai/... : POST payload
+    Proxy ->> Cosmos DB : Save task (status="queued")
+    Proxy ->> Azure Service Bus : Enqueue task
+    Celery Worker ->> Azure Bus : Poll
+    Worker ->> AI Backend : POST for processing
+    Worker ->> Cosmos DB : Save (status="completed" + response)
+    Customer ->> /taskadmin/tasks/{id}?part=response : Fetch result
+```
+
+---
+
+## 1.8 Guia Rápido de Tratamento de Erros
+
+| **Status**  | **Significado**            | **Próximo Passo**                         |
+| ----------- | -------------------------- | ----------------------------------------- |
+| `queued`    | Aguardando worker livre    | Verifique `/queue/stats` para backlog     |
+| `completed` | Resultado pronto           | Faça o download                           |
+| `failed`    | Erro ou timeout            | Inspecione o campo `error`; retente se transitório |
+
+---
+
+## 1.9 FAQ
+
+* **Quanto tempo os resultados ficam disponíveis?**
+  ⏳ 30 dias (padrão)
+
+* **Posso cancelar um job?**
+  ❌ Ainda não – abra um ticket de suporte
+
+* **Timeouts?**
+  ⏱️ Timeout rígido de 60s; divida jobs grandes
+
+* **Segurança?**
+  🔐 TLS 1.2 para todos os dados em trânsito
+  🔒 Segredos com hash em repouso
+
+---

--- a/2.authentication-and-conventions.es.md
+++ b/2.authentication-and-conventions.es.md
@@ -1,0 +1,9 @@
+## 2. Autenticación & Convenciones
+
+### Encabezados Requeridos
+
+| **Encabezado**       | **Propósito**           | **Notas** |
+| -------------------- | ---------------------- | -------------------------------------------- |
+| `X-Customer-Api-Id` | UUID del cliente (v4)   | ✅ **Obligatorio** si no se usa clave de administrador |
+| `X-Secret`          | Secreto de 64 caracteres | 🔁 Rotar cada **90 días** |
+| `Accept-Language`   | Idioma de la respuesta   | 🌐 Opciones: `en` (por defecto), `es`, `pt` <br>🔄 Sobrescribe el parámetro `lang` del cuerpo |

--- a/2.authentication-and-conventions.pt.md
+++ b/2.authentication-and-conventions.pt.md
@@ -1,0 +1,9 @@
+## 2. Autenticação & Convenções
+
+### Cabeçalhos Requeridos
+
+| **Cabeçalho**        | **Propósito**            | **Notas** |
+| ------------------- | ----------------------- | --------------------------------------------- |
+| `X-Customer-Api-Id` | UUID do cliente (v4)    | ✅ **Obrigatório** se nenhuma chave de admin for usada |
+| `X-Secret`          | Segredo de 64 caracteres | 🔁 Rotacionar a cada **90 dias** |
+| `Accept-Language`   | Idioma da resposta       | 🌐 Opções: `en` (padrão), `es`, `pt` <br>🔄 Sobrescreve o parâmetro `lang` no corpo |

--- a/3.route-catalogue.es.md
+++ b/3.route-catalogue.es.md
@@ -1,0 +1,11 @@
+## 3. Catálogo de Rutas (Vista Rápida)
+
+> **Nota:** Todos los caminos usan el formato `POST /api/v1/ai/{route}`
+
+| **Pilar**                  | **Rutas (cada camino es `POST /api/v1/ai/...`)** |
+| -------------------------- | ------------------------------------------------ |
+| **Customer Intelligence**  | `purchasing_segmentation*`, `segmentation_report*`, `segment_hierarchy_chart`, `segment_subsegment_explore`, `segment_cluster_profiles`, `customer_segmentation`, `customer_features`, `customer_loyalty`, `customer_rfm`, `customer_clv_features`, `customer_clv_forecast`, `churn_risk`, `nps`, `churn_label` |
+| **Propensity & Recommendation** | `propensity_buy_product`, `propensity_respond_campaign`, `propensity_upgrade_plan`, `recommend_user_items`, `recommend_similar_items`, `cross_sell_matrix`, `upsell_suggestions`, `dynamic_pricing_recommend`, `uplift_model` |
+| **Forecasting & Planning** | `forecast_revenue`, `forecast_units`, `forecast_units_asyncio`, `forecast_cost`, `forecast_cost_improved`, `forecast_cost_totus` |
+| **Inventory & Supply-Chain** | `inventory_history_improved`, `inventory_optimization`, `nlp_openai_excess_inventory_report`, `excess_inventory_nlp`, `nlp_analisys`, `nlp_analisys_en` |
+| **Cost & Risk Analytics**  | `credit_risk_score`, `credit_risk_explain`, `channel_attribution`, `journey_markov`, `journey_sequences`, `anomaly_transactions`, `anomaly_accounts`, `anomaly_graph`, `sentiment_report`, `sentiment_realtime` |

--- a/3.route-catalogue.pt.md
+++ b/3.route-catalogue.pt.md
@@ -1,0 +1,11 @@
+## 3. Catálogo de Rotas (Visão Rápida)
+
+> **Nota:** Todos os caminhos usam o formato `POST /api/v1/ai/{route}`
+
+| **Pilar**                    | **Rotas (todo caminho é `POST /api/v1/ai/...`)** |
+| ---------------------------- | ------------------------------------------------ |
+| **Customer Intelligence**    | `purchasing_segmentation*`, `segmentation_report*`, `segment_hierarchy_chart`, `segment_subsegment_explore`, `segment_cluster_profiles`, `customer_segmentation`, `customer_features`, `customer_loyalty`, `customer_rfm`, `customer_clv_features`, `customer_clv_forecast`, `churn_risk`, `nps`, `churn_label` |
+| **Propensity & Recommendation** | `propensity_buy_product`, `propensity_respond_campaign`, `propensity_upgrade_plan`, `recommend_user_items`, `recommend_similar_items`, `cross_sell_matrix`, `upsell_suggestions`, `dynamic_pricing_recommend`, `uplift_model` |
+| **Forecasting & Planning**   | `forecast_revenue`, `forecast_units`, `forecast_units_asyncio`, `forecast_cost`, `forecast_cost_improved`, `forecast_cost_totus` |
+| **Inventory & Supply-Chain** | `inventory_history_improved`, `inventory_optimization`, `nlp_openai_excess_inventory_report`, `excess_inventory_nlp`, `nlp_analisys`, `nlp_analisys_en` |
+| **Cost & Risk Analytics**    | `credit_risk_score`, `credit_risk_explain`, `channel_attribution`, `journey_markov`, `journey_sequences`, `anomaly_transactions`, `anomaly_accounts`, `anomaly_graph`, `sentiment_report`, `sentiment_realtime` |

--- a/4.detailed-route-reference.es.md
+++ b/4.detailed-route-reference.es.md
@@ -1,0 +1,3 @@
+# 4. Referencia Detallada de Rutas
+
+_Traducción pendiente. Consulte el archivo original `4.detailed-route-reference.md` para detalles completos._

--- a/4.detailed-route-reference.pt.md
+++ b/4.detailed-route-reference.pt.md
@@ -1,0 +1,3 @@
+# 4. Referência Detalhada de Rotas
+
+_Tradução pendente. Consulte o arquivo original `4.detailed-route-reference.md` para detalhes completos._


### PR DESCRIPTION
## Summary
- add Portuguese and Spanish versions of executive summary
- document authentication headers in Portuguese and Spanish
- translate route catalogue to Portuguese and Spanish
- add placeholders for detailed route reference translations

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4de4ac3083329c597ef03009ab6e